### PR TITLE
Retarget platform to FTDI-flashed Pro Mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# See docs/README.md for the project overview.
+# LineLight-1 Production Kit
+
+Welcome to the gutsy little repo that makes a band-responsive lamp glow on cue. You're in the right place if you want to build, audit, or remix LineLight-1 for production deployment.
+
+## How to Use This Repo
+- **Need the concept sketch?** Hit [`docs/README.md`](docs/README.md) for the full story, signal path, and ethics.
+- **Building hardware tonight?** Jump to [`docs/build-guide.md`](docs/build-guide.md), then stroll through [`hardware/`](hardware/).
+- **Flashing firmware?** The PlatformIO project lives under [`firmware/`](firmware/). Clip a SparkFun FTDI Basic (5 V) onto the
+  Pro Mini header, then `pio run -t upload` and you’re moshing.
+- **Coordinating production runs?** Check the BOM notes in [`bom/`](bom/) and the manufacturing/testing briefs in [`docs/manufacturing.md`](docs/manufacturing.md) and [`docs/testing.md`](docs/testing.md).
+
+## Production-lean Defaults
+- Firmware is tuned for a release build (`-Os`, LTO, dead-strip). See [`firmware/platformio.ini`](firmware/platformio.ini).
+- Tooling assumes the **FTDI-programmed SparkFun Pro Mini (5 V/16 MHz)**—no onboard USB, so route the 6-pin header.
+- Documentation now includes subsystem diagrams so your fabricator, firmware hacker, and QA engineer speak the same language.
+- Every sketch, schematic, and README is annotated like a zine—follow the breadcrumbs, learn the intent, remix responsibly.
+
+## What Changed Recently?
+- Added architecture diagrams to teach the signal flow at a glance.
+- Expanded inline comments so future you knows **why** each design choice exists.
+- Tightened the build flags for a quieter, cooler-running microcontroller.
+
+Now go build something that glows with purpose.

--- a/bom/bom.csv
+++ b/bom/bom.csv
@@ -1,5 +1,5 @@
 qty,designator,description,example_part,notes
-1,U1,Arduino Pro Micro 5V/16MHz,SparkFun Pro Micro 5V,USB‑native MCU
+1,U1,SparkFun Pro Mini 5V/16MHz,SparkFun Pro Mini 5V,Needs external FTDI for programming
 1,U2,Dual RRIO op‑amp,MCP6002,Audio buffer and bias amp
 2,J1/J2,TRS audio jacks,Neutrik/Rean,,IN/OUT
 1,Q1,Logic‑level N‑MOSFET,AO3400/IRLZ44N,LED lamp driver
@@ -16,3 +16,4 @@ qty,designator,description,example_part,notes
 1,Rpd,100k 1%,Any,MOSFET gate pulldown
 2,VR1/VR2,10k–50k lin pots,Alpha/Bourns,Band select
 1,TVS,12V rail TVS,SMAJ18A,Optional protection
+1,PROG,FTDI Basic (5V),SparkFun DEV-09716,6-pin header mates to Pro Mini

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,51 @@
 # LineLight‑1 — a listening lamp for artists
 
-**One lamp, two knobs, line‑through.** LineLight‑1 listens to a band of the spectrum on your **line‑level** signal and maps its energy to a clean, quiet LED brightness. No capture, no telemetry—just glow.
+**One lamp, two knobs, line‑through.** LineLight‑1 listens to a slice of your **line‑level** signal and maps its
+energy to a clean, quiet LED brightness. No capture, no telemetry—just glow.
+
+## System-at-a-glance
+```mermaid
+flowchart LR
+    subgraph Analog Porch
+        LR["L/R Inputs"] -->|passive sum| SUM
+        SUM --> BUF["MCP6002 Buffer"]
+        BUF --> THROUGH["Line Through Out"]
+        BUF --> AC["AC Coupling"] --> BIAS["VCC/2 Bias & RC"] --> ADC["ADC A0"]
+        ADC --> CLAMP["Schottky Clamp"]
+    end
+    subgraph Brain & Power
+        POT1["Pot 1 → A1"]
+        POT2["Pot 2 → A2"]
+        MCU["ATmega328P (Pro Mini)"]
+        LEDDRV["31 kHz PWM → MOSFET"]
+        POT1 --> MCU
+        POT2 --> MCU
+        ADC --> MCU
+        MCU --> LEDDRV
+        LEDDRV --> LAMP["12 V LED Lamp"]
+        PSU["12 V In"] --> BUCK["Buck 12→5 V"] --> MCU
+        PSU --> LAMP
+    end
+```
+
+The analog porch stays transparent while the digital core analyses the energy band you dial in. No wireless, no
+cloud, no surprises.
+
+## Firmware signal flow
+```mermaid
+sequenceDiagram
+    participant Audio as Audio Samples
+    participant FFT as Windowed FFT
+    participant Band as Band Picker
+    participant AGC as AGC + Smoothing
+    participant PWM as Gamma PWM
+
+    Audio->>FFT: Spin-wait sampling @ 9.6 kHz
+    FFT->>Band: Magnitudes (N=256)
+    Band->>AGC: Mean energy of selected bins
+    AGC->>PWM: Normalized level (0..1)
+    PWM->>LED: 31 kHz duty update
+```
 
 ## Why
 - On stage or in studio you need a **legible**, **non-distracting** cue.
@@ -20,19 +65,20 @@
    - AC‑couple → bias at VCC/2 → ADC (A0) with small RC.
    - Schottky clamps to protect the ADC.
 2. Wire MOSFET gate to **D9**; 12 V LED lamp on the drain; common ground.
-3. Flash firmware via **PlatformIO**:
+3. Flash firmware via **PlatformIO** using a SparkFun **FTDI Basic (5 V)** on the 6-pin programming header:
    ```sh
    pio run -t upload
    pio device monitor
    ```
+   Wire DTR→RESET, TXO→RXI, RXI→TXO, VCC→VCC (5 V), CTS→GND. The Pro Mini has no native USB, so this header is your lifeline.
 4. Send pink noise; turn the knobs to pick your band. The lamp should breathe to the music.
 
 ## Safety
-- Ship **low‑voltage** only by default (12 V LED loads). If you need mains dimming, use a certified SSR/triac module in an enclosed, fused chassis and treat this repo as **control‑signal only**.
+- Ship **low‑voltage** only by default (12 V LED loads). If you need mains dimming, use a certified SSR/triac module in an enclosed, fused chassis and treat this repo as **control-signal only**.
 - Audio grounds can be fickle. If you hear hum in certain rigs, add the **isolation transformer** variant.
 
 ## Limitations & upgrades
-- Pro Micro FFT is coarse; for sharper bands use a **Teensy** or external **MSGEQ7**.
+- Pro Mini FFT is coarse; for sharper bands use a **Teensy** or external **MSGEQ7**.
 - v0.1 is **unbalanced** I/O. v1.1 adds transformers or THAT‑based balanced front/back.
 - Add BLE/UART config later to set bands without opening the box.
 

--- a/docs/build-guide.md
+++ b/docs/build-guide.md
@@ -3,7 +3,8 @@
 This is the quickest path to a reliable prototype. Keep leads short and star‑ground power returns.
 
 ## 1) Parts
-- Arduino Pro Micro (5 V, 16 MHz, ATmega32u4)
+- SparkFun Pro Mini (5 V, 16 MHz, ATmega328P)
+- SparkFun FTDI Basic (5 V) or equivalent 6-pin USB‑serial adapter
 - MCP6002 (dual RRIO op‑amp) + socket
 - TRS jacks (in/out) or 3.5 mm equivalents
 - Film cap 1 µF, ceramics 1 nF, electrolytics 10–100 µF
@@ -45,6 +46,7 @@ Notes:
 - Add a TVS (e.g., SMAJ18A) on 12 V if you expect hot‑plugging.
 
 ## 6) Flash & test
+- Wire the FTDI Basic: DTR→RESET, TXO→RXI, RXI→TXO, VCC→VCC (5 V), CTS→GND.
 - `pio run -t upload`
 - Open serial monitor @115200. You should see bin edges and levels once per second.
 - Sweep the knobs and watch the frequency readout change.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,0 +1,36 @@
+# Firmware shop manual
+
+This folder houses the PlatformIO project that turns spectral energy into lamp brightness. The comments in `src/main.cpp`
+are intentionally long-form so you know the thinking behind every line. Target hardware is the SparkFun **Pro Mini 5 V/16 MHz**
+flashed through a SparkFun FTDI Basic (5 V).
+
+## Build + flash
+```sh
+pio run
+pio run -t upload
+pio device monitor
+```
+- Hook up the FTDI Basic: DTR→RESET, TXO→RXI, RXI→TXO, VCC→VCC (5 V), CTS→GND.
+- `pio run -t upload` toggles DTR to reset the Pro Mini—no extra button mashing required if the header is wired right.
+
+## Module map
+```mermaid
+flowchart TD
+    sampler["Sampler<br/>spin-wait loop"] --> fft["FFT core" ]
+    fft --> band["Band picker"]
+    band --> agc["AGC + EMA"]
+    agc --> gamma["Gamma mapper"]
+    gamma --> pwm["31 kHz PWM" ]
+```
+
+- **Sampler** holds timing steady without ISRs so the analog porch can be debugged in isolation.
+- **FFT core** uses `arduinoFFT` with a Hann window you can audit in ROM.
+- **Band picker** translates the panel knobs into bin ranges with guard rails.
+- **AGC + EMA** does the vibe-polishing—no hard clipping, no drama.
+- **Gamma mapper** makes LED brightness feel linear to human eyes.
+- **31 kHz PWM** keeps the MOSFET and lamp silent.
+
+## Production notes
+- Release build flags (`-Os`, LTO, section GC) are set in `platformio.ini` so shipping firmware runs cool.
+- Serial logs throttle to 1 Hz so the FTDI stream stays readable during validation.
+- If you move to an ISR sampler later, keep the function boundaries—they make it trivial to unit-test on a desktop build.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,12 +1,21 @@
-; LineLight-1 PlatformIO config
-[env:sparkfun_promicro16]
+; LineLight-1 PlatformIO config — tuned for production builds
+[env:sparkfun_promini16]
 platform = atmelavr
-board = sparkfun_promicro16
+board = sparkfun_promini16
 framework = arduino
-lib_deps = 
+build_type = release
+build_flags =
+    -Os
+    -flto
+    -ffunction-sections
+    -fdata-sections
+    -Wall
+    -Wextra
+    -Werror=return-type
+; Link-time garbage collection keeps the firmware lean and the MCU cooler.
+ldflags =
+    -Wl,-Os
+    -Wl,--gc-sections
+lib_deps =
     arduinoFFT
 monitor_speed = 115200
-build_flags =
-    -DUSB_VID=0x1B4F
-    -DUSB_PID=0x9206
-    -DUSB_PRODUCT="LineLight-1"

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,146 +1,259 @@
 // LineLight-1: Single-lamp, band-limited LED level from line audio
-// Target: Arduino Pro Micro (ATmega32u4, 5V/16MHz)
+// Target: SparkFun Pro Mini (ATmega328P, 5V/16MHz) flashed via FTDI Basic
 //
-// Signal path summary:
-//   Audio L/R -> passive sum -> op-amp buffer -> AC couple -> VCC/2 bias -> ADC (A0)
-//   Two pots (A1/A2) select FFT band [bin_lo..bin_hi]; energy drives PWM on pin 9 (OC1A)
-//
-// NOTE: This is a minimal, production-leaning prototype: polling sampler + FFT.
-//       Upgrade sampling to a timer ISR after validating analog front-end.
+// This file intentionally reads like a tour guide. Every stage is annotated so you can hand it to a
+// manufacturing test tech, a firmware intern, or future-you and they all get the "why" as well as the "what".
+// Nothing here is "magic"—the punk ethos is transparency.
 
 #include <Arduino.h>
 #include <arduinoFFT.h>
 
-// ---------- Pins (adjust to your wiring) ----------
-static const uint8_t PIN_AUDIO = A0;   // biased at VCC/2
-static const uint8_t PIN_POT1  = A1;   // low edge selector
-static const uint8_t PIN_POT2  = A2;   // high edge selector
-static const uint8_t PIN_PWM   = 9;    // OC1A on 32u4 (LED lamp MOSFET gate)
+// -----------------------------------------------------------------------------
+// Pin map — keep the numbers here so harness diagrams and firmware match.
+// -----------------------------------------------------------------------------
+static const uint8_t PIN_AUDIO = A0;   // Audio feed, AC-coupled and biased around VCC/2.
+static const uint8_t PIN_POT1  = A1;   // Potentiometer selecting the low edge of the FFT band.
+static const uint8_t PIN_POT2  = A2;   // Potentiometer selecting the high edge of the FFT band.
+static const uint8_t PIN_PWM   = 9;    // Timer1 OC1A output → MOSFET gate driving the lamp.
 
-// ---------- FFT setup ----------
-static const uint16_t N  = 256;        // FFT size
-static const float    Fs = 9600.0f;    // sampling rate (Hz)
-static const uint32_t SAMPLE_DT_US = (uint32_t)(1000000.0f / Fs + 0.5f);
+// -----------------------------------------------------------------------------
+// FFT / DSP constants — tuned for a 9.6 kHz sample rate which plays nicely with the loop timing.
+// -----------------------------------------------------------------------------
+static const uint16_t FFT_BIN_COUNT = 256;            // Power-of-two for the library FFT.
+static const float    SAMPLE_RATE_HZ = 9600.0f;       // Set by our crude spin-wait sampler.
+static const uint32_t SAMPLE_PERIOD_US =              // Microseconds between samples.
+    static_cast<uint32_t>(1000000.0f / SAMPLE_RATE_HZ + 0.5f);
+static const uint16_t ADC_BIAS = 512;                 // 10-bit ADC mid-point after bias network.
 
-arduinoFFT FFT;
-double vReal[N];
-double vImag[N];
+// -----------------------------------------------------------------------------
+// AGC / smoothing constants — values chosen by ear for a smooth, musical response.
+// -----------------------------------------------------------------------------
+static const double EMA_ALPHA     = 0.20;   // Weight of the current FFT frame in the exponential moving average.
+static const double TARGET_LEVEL  = 0.35;   // Normalized level we try to hover around after AGC.
+static const double AGC_STEP      = 0.015;  // How aggressively the AGC reacts to error.
+static const double AGC_MIN_GAIN  = 0.05;   // Safety floor to prevent locking up on silence.
+static const double AGC_MAX_GAIN  = 200.0;  // Safety ceiling to avoid numeric blow-ups.
+static const double PWM_GAMMA     = 2.0;    // Gamma curve to tame perceived brightness steps.
 
-// Hann window (computed at startup)
-double hann[N];
+// -----------------------------------------------------------------------------
+// Working buffers — global to avoid stack thrash.
+// -----------------------------------------------------------------------------
+static arduinoFFT FFT;
+static double vReal[FFT_BIN_COUNT];
+static double vImag[FFT_BIN_COUNT];
+static double hannWindow[FFT_BIN_COUNT];
 
-// AGC / smoothing
-double ema = 0.0;
-double agc = 1.0;
+// -----------------------------------------------------------------------------
+// State for the slow-control loops.
+// -----------------------------------------------------------------------------
+static double emaEnergy = 0.0;   // Exponential moving average of band energy.
+static double agcGain   = 1.0;   // Adaptive gain multiplier.
 
-// Forward declarations
+// -----------------------------------------------------------------------------
+// Utility prototypes.
+// -----------------------------------------------------------------------------
 void setupFastPWM31kHz();
-inline void pwmWrite(uint8_t d) { OCR1A = d; }  // direct write (Timer1, OC1A -> D9)
+inline void pwmWrite(uint8_t duty) { OCR1A = duty; }
 
+void primeHannWindow();
+void acquireWindowedSamples();
+void performFft();
+
+struct BandSelection {
+  uint16_t binLo;
+  uint16_t binHi;
+};
+BandSelection readBandSelection();
+double computeBandEnergy(uint16_t binLo, uint16_t binHi);
+double normalizeEnergy(double rawEnergy);
+uint8_t renderDutyFromLevel(double level);
+void logDebugOncePerSecond(const BandSelection& band, double level);
+
+// -----------------------------------------------------------------------------
+// setup() — Configure serial, ADC expectations, PWM hardware, and precompute the Hann window.
+// -----------------------------------------------------------------------------
 void setup() {
   Serial.begin(115200);
   pinMode(PIN_PWM, OUTPUT);
-  analogReadResolution(10);              // 0..1023
-  analogReference(DEFAULT);              // 5V reference
 
-  // Precompute Hann
-  for (uint16_t n=0; n<N; ++n) {
-    hann[n] = 0.5 * (1.0 - cos(2.0 * PI * n / (N - 1)));
-  }
+  // AVR analogRead is always 10-bit, but calling this documents intent when ported.
+#if defined(analogReadResolution)
+  analogReadResolution(10);
+#endif
+  analogReference(DEFAULT);  // Using VCC (5 V) as reference; matches the bias divider assumption.
 
+  primeHannWindow();
   setupFastPWM31kHz();
-  pwmWrite(0);
+  pwmWrite(0);  // Guarantee the lamp is off during boot.
 
-  // Small boot banner
-  delay(50);
+  delay(50);  // Let the FTDI Basic and host terminal settle before spitting logs.
   Serial.println(F("LineLight-1 boot"));
-  Serial.print(F("Fs=")); Serial.println(Fs);
-  Serial.print(F("N="));  Serial.println(N);
+  Serial.print(F("Fs=")); Serial.println(SAMPLE_RATE_HZ);
+  Serial.print(F("N="));  Serial.println(FFT_BIN_COUNT);
 }
 
+// -----------------------------------------------------------------------------
+// loop() — One pass = sample → FFT → band energy → AGC → PWM update → optional debug log.
+// -----------------------------------------------------------------------------
 void loop() {
-  // --- Acquire N samples with crude timing control ---
-  uint32_t tNext = micros();
-  for (uint16_t i=0; i<N; ++i) {
-    // Simple sample-time control; avoids interrupts for first proto
-    while ((int32_t)(micros() - tNext) < 0) { /* spin */ }
-    tNext += SAMPLE_DT_US;
-
-    int raw = analogRead(PIN_AUDIO);  // 0..1023, ~512 mid (biased)
-    double centered = (double)raw - 512.0; // center around 0
-    // Window
-    vReal[i] = centered * hann[i];
-    vImag[i] = 0.0;
-  }
-
-  // --- FFT ---
-  FFT.Windowing(vReal, N, FFT_WIN_TYP_RECTANGLE, FFT_FORWARD); // window already applied
-  FFT.Compute(vReal, vImag, N, FFT_FORWARD);
-  FFT.ComplexToMagnitude(vReal, vImag, N);
-
-  // --- Read pots and map to bins ---
-  int p1 = analogRead(PIN_POT1);  // 0..1023
-  int p2 = analogRead(PIN_POT2);
-  uint16_t nyq = (N/2) - 1;
-  uint16_t binLo = map(p1, 0, 1023, 1, nyq-1);
-  uint16_t binHi = map(p2, 0, 1023, binLo+1, nyq);
-  if (binHi <= binLo) binHi = binLo + 1;
-
-  // --- Band energy ---
-  double e = 0.0;
-  for (uint16_t b = binLo; b <= binHi; ++b) {
-    double m = vReal[b];
-    e += m * m;
-  }
-
-  // Normalize by number of bins for consistent feel
-  e /= (double)(binHi - binLo + 1);
-
-  // --- AGC + smoothing ---
-  const double alpha  = 0.2;  // EMA factor (~10–50 ms feel depending on Fs/N loop)
-  const double target = 0.35; // desired normalized level
-  ema = (1.0 - alpha) * ema + alpha * e;
-  // Nudge agc to keep ema*agc near target
-  double err = target - min(1.0, ema * agc);
-  agc *= (1.0 + 0.015 * err);
-  agc = constrain(agc, 0.05, 200.0);
-
-  // Compress, gamma-correct, scale to 8-bit PWM
-  double level = sqrt(ema * agc);            // soft comp
-  level = constrain(level, 0.0, 1.0);
-  const double gamma = 2.0;
-  uint8_t duty = (uint8_t)(pow(level, gamma) * 255.0 + 0.5);
+  acquireWindowedSamples();      // 1. Pull N samples into vReal/vImag with Hann applied.
+  performFft();                  // 2. Transform into magnitude space.
+  BandSelection band = readBandSelection();
+  double bandEnergy = computeBandEnergy(band.binLo, band.binHi);
+  double normalized = normalizeEnergy(bandEnergy);
+  uint8_t duty = renderDutyFromLevel(normalized);
   pwmWrite(duty);
+  logDebugOncePerSecond(band, normalized);
+}
 
-  // --- Debug once per second ---
-  static uint32_t tLast = 0;
-  if (millis() - tLast > 1000) {
-    tLast = millis();
-    double binWidth = Fs / (double)N;
-    Serial.print(F("bins ")); Serial.print(binLo); Serial.print('-'); Serial.print(binHi);
-    Serial.print(F(" (")); Serial.print(binLo*binWidth,0); Serial.print('-'); Serial.print(binHi*binWidth,0); Serial.print(F(" Hz) "));
-    Serial.print(F("level ")); Serial.print(level,3);
-    Serial.print(F("  agc ")); Serial.print(agc,3);
-    Serial.print(F("  ema ")); Serial.println(ema,3);
+// -----------------------------------------------------------------------------
+// primeHannWindow() — Precompute Hann coefficients so each frame just multiplies.
+// -----------------------------------------------------------------------------
+void primeHannWindow() {
+  for (uint16_t n = 0; n < FFT_BIN_COUNT; ++n) {
+    const double phase = (2.0 * PI * n) / (FFT_BIN_COUNT - 1);
+    hannWindow[n] = 0.5 * (1.0 - cos(phase));
   }
 }
 
-// Configure Timer1 for ~31 kHz PWM on OC1A (D9) using phase-correct 8-bit
-void setupFastPWM31kHz() {
-  // Disconnect analogWrite from Timer1 on pin 9 if previously set
-  pinMode(PIN_PWM, OUTPUT);
+// -----------------------------------------------------------------------------
+// acquireWindowedSamples() — Spin-wait sampling keeps phase predictable without ISR complexity.
+// -----------------------------------------------------------------------------
+void acquireWindowedSamples() {
+  uint32_t nextSampleMicros = micros();
+  for (uint16_t i = 0; i < FFT_BIN_COUNT; ++i) {
+    // Busy-wait until the planned sample time. On 16 MHz AVR this lands within a few CPU cycles.
+    while (static_cast<int32_t>(micros() - nextSampleMicros) < 0) {
+      // Intentional empty body: we want deterministic timing without interrupts for v0.1.
+    }
+    nextSampleMicros += SAMPLE_PERIOD_US;
 
-  // Clear control registers
+    int raw = analogRead(PIN_AUDIO);                 // 0..1023, biased around ~512.
+    double centered = static_cast<double>(raw) - ADC_BIAS;  // Remove the DC bias from the buffer.
+    vReal[i] = centered * hannWindow[i];              // Apply window to reduce spectral leakage.
+    vImag[i] = 0.0;                                   // Start with zero imaginary part.
+  }
+}
+
+// -----------------------------------------------------------------------------
+// performFft() — Classic FFT dance: window (already done) → compute → magnitude.
+// -----------------------------------------------------------------------------
+void performFft() {
+  FFT.Windowing(vReal, FFT_BIN_COUNT, FFT_WIN_TYP_RECTANGLE, FFT_FORWARD);  // Library expects a call even if windowed.
+  FFT.Compute(vReal, vImag, FFT_BIN_COUNT, FFT_FORWARD);
+  FFT.ComplexToMagnitude(vReal, vImag, FFT_BIN_COUNT);
+}
+
+// -----------------------------------------------------------------------------
+// readBandSelection() — Convert pot voltages into FFT bin indices, honoring Nyquist limits.
+// -----------------------------------------------------------------------------
+BandSelection readBandSelection() {
+  const uint16_t nyquistBin = (FFT_BIN_COUNT / 2) - 1;  // Ignore mirrored bins.
+
+  int pot1 = analogRead(PIN_POT1);  // 0..1023
+  int pot2 = analogRead(PIN_POT2);
+
+  // Convert to floating point ratios for smoother scaling than Arduino's integer map().
+  double loRatio = constrain(static_cast<double>(pot1) / 1023.0, 0.0, 1.0);
+  double hiRatio = constrain(static_cast<double>(pot2) / 1023.0, 0.0, 1.0);
+
+  uint16_t binLo = 1 + static_cast<uint16_t>(loRatio * (nyquistBin - 2));
+  uint16_t binHi = binLo + 1 + static_cast<uint16_t>(hiRatio * (nyquistBin - binLo - 1));
+  binHi = constrain(binHi, static_cast<uint16_t>(binLo + 1), nyquistBin);
+
+  return {binLo, binHi};
+}
+
+// -----------------------------------------------------------------------------
+// computeBandEnergy() — Sum magnitudes squared within the chosen band and average them.
+// -----------------------------------------------------------------------------
+double computeBandEnergy(uint16_t binLo, uint16_t binHi) {
+  double accumulator = 0.0;
+  for (uint16_t bin = binLo; bin <= binHi; ++bin) {
+    double magnitude = vReal[bin];  // vReal holds magnitudes after ComplexToMagnitude().
+    accumulator += magnitude * magnitude;
+  }
+
+  const uint16_t binCount = (binHi - binLo + 1);
+  return accumulator / static_cast<double>(binCount);
+}
+
+// -----------------------------------------------------------------------------
+// normalizeEnergy() — Apply smoothing + AGC so LED motion feels organic instead of twitchy.
+// -----------------------------------------------------------------------------
+double normalizeEnergy(double rawEnergy) {
+  // Update exponential moving average to keep short bursts from jittering the light.
+  emaEnergy = (1.0 - EMA_ALPHA) * emaEnergy + EMA_ALPHA * rawEnergy;
+
+  // Compute error between where we are and where we want to be, then tweak the gain.
+  double normalizedMeasure = min(1.0, emaEnergy * agcGain);
+  double error = TARGET_LEVEL - normalizedMeasure;
+  agcGain *= (1.0 + AGC_STEP * error);
+  agcGain = constrain(agcGain, AGC_MIN_GAIN, AGC_MAX_GAIN);
+
+  // Return the post-AGC level in the 0..1 range, squared for mild compression.
+  double leveled = sqrt(emaEnergy * agcGain);
+  return constrain(leveled, 0.0, 1.0);
+}
+
+// -----------------------------------------------------------------------------
+// renderDutyFromLevel() — Gamma-correct the normalized level and map to an 8-bit PWM duty.
+// -----------------------------------------------------------------------------
+uint8_t renderDutyFromLevel(double level) {
+  double gammaCorrected = pow(level, PWM_GAMMA);
+  gammaCorrected = constrain(gammaCorrected, 0.0, 1.0);
+  return static_cast<uint8_t>(gammaCorrected * 255.0 + 0.5);
+}
+
+// -----------------------------------------------------------------------------
+// logDebugOncePerSecond() — Print bin edges, their rough Hz equivalents, and the AGC state.
+// -----------------------------------------------------------------------------
+void logDebugOncePerSecond(const BandSelection& band, double level) {
+  static uint32_t lastLogMs = 0;
+  if (millis() - lastLogMs < 1000) {
+    return;
+  }
+  lastLogMs = millis();
+
+  const double binWidthHz = SAMPLE_RATE_HZ / static_cast<double>(FFT_BIN_COUNT);
+  const double loHz = band.binLo * binWidthHz;
+  const double hiHz = band.binHi * binWidthHz;
+
+  Serial.print(F("bins "));
+  Serial.print(band.binLo);
+  Serial.print('-');
+  Serial.print(band.binHi);
+  Serial.print(F(" ("));
+  Serial.print(loHz, 0);
+  Serial.print('-');
+  Serial.print(hiHz, 0);
+  Serial.print(F(" Hz) "));
+  Serial.print(F("level "));
+  Serial.print(level, 3);
+  Serial.print(F("  agc "));
+  Serial.print(agcGain, 3);
+  Serial.print(F("  ema "));
+  Serial.println(emaEnergy, 3);
+}
+
+// -----------------------------------------------------------------------------
+// setupFastPWM31kHz() — Configure Timer1 for high-frequency PWM on OC1A (pin 9).
+// -----------------------------------------------------------------------------
+void setupFastPWM31kHz() {
+  pinMode(PIN_PWM, OUTPUT);  // Ensure pin is driven by Timer1 hardware.
+
+  // Reset control registers before configuring. This avoids ghosts from Arduino's analogWrite().
   TCCR1A = 0;
   TCCR1B = 0;
 
-  // Phase Correct PWM 8-bit: WGM10=1
+  // Waveform Generation Mode: Phase Correct PWM, 8-bit (WGM10 = 1).
   TCCR1A |= _BV(WGM10);
-  // No prescaling: CS10=1
+
+  // Clock select: no prescaler (CS10 = 1). 16 MHz / 510 ≈ 31.37 kHz PWM frequency.
   TCCR1B |= _BV(CS10);
-  // Clear OC1A on up-count compare, set on down-count compare (non-inverting)
+
+  // Compare Output Mode: non-inverting on OC1A so 0 = off, 255 = full-on.
   TCCR1A |= _BV(COM1A1);
 
-  // Start with 0 duty
-  OCR1A = 0;
+  OCR1A = 0;  // Start with the lamp off.
 }

--- a/hardware/LineLight-1.kicad_sch
+++ b/hardware/LineLight-1.kicad_sch
@@ -12,7 +12,7 @@
 
 (text "Audio I/O (TRS/through)" (at 20.00 20.00 0) (effects (font (size 2.2 2.2))))
 (text "Op-Amp envelope detector + bias" (at 20.00 60.00 0) (effects (font (size 2.2 2.2))))
-(text "ADC → Pro Micro 5V" (at 120.00 60.00 0) (effects (font (size 2.2 2.2))))
+(text "ADC → Pro Mini 5V" (at 120.00 60.00 0) (effects (font (size 2.2 2.2))))
 (text "Lamp driver (logic-level N-MOSFET)" (at 120.00 20.00 0) (effects (font (size 2.2 2.2))))
 (text "User controls (pots set FFT window)" (at 20.00 100.00 0) (effects (font (size 2.2 2.2))))
 (symbol (lib_id "power:+12V") (at 145.00 14.00 0) (unit 1)
@@ -432,7 +432,7 @@
 (polyline (pts (xy 15.00 95.00) (xy 105.00 95.00) (xy 105.00 122.00) (xy 15.00 122.00) (xy 15.00 95.00)) (stroke (width 0.1524) (type solid)) (uuid 3f23d0bd-0360-4b7e-8969-a2853c7a1ee1))
 (text "Finish by wiring pins to labels on a 2.54 mm grid.
 Annotate, then Assign Footprints.
-Pro Micro pins: map A0, D9, +5V, GND accordingly." (at 110.00 96.00 0) (effects (font (size 1.4 1.4))))
+Pro Mini pins: map A0, D9, +5V, GND accordingly." (at 110.00 96.00 0) (effects (font (size 1.4 1.4))))
   (path
     "/"
     (page "1")

--- a/hardware/schematic.md
+++ b/hardware/schematic.md
@@ -1,8 +1,32 @@
-# Schematic (placeholder)
+# Schematic crib notes
 
-This folder will hold the KiCad/EasyEDA sources. For now, see **docs/build-guide.md** for the reference hookups.
+This folder will hold the KiCad/EasyEDA sources. Until the official schematic drops, use the annotated map below to keep the bench wiring honest.
+
+```mermaid
+flowchart TD
+    INL["Line In L"] --> SUM
+    INR["Line In R"] --> SUM
+    SUM["1k/1k Passive Summer"] --> BUF["MCP6002 Buffer (A)"]
+    BUF --> THRU["Line Through Out"]
+    BUF --> HPF["AC Coupler 1 µF"] --> BIAS["VCC/2 Bias Node"] --> RC["10k//1 nF RC"] --> ADC["ATmega328P A0"]
+    ADC --> CLAMP["BAT54 Clamp"]
+
+    POT1["POT1 → A1"] --> MCU
+    POT2["POT2 → A2"] --> MCU
+    MCU["ATmega328P (Pro Mini)"] --> GATE["100 Ω Gate"] --> FET["Logic MOSFET"] --> LAMP["12 V LED Fixture"]
+    PSU["12 V DC"] -->{feeds}
+    {feeds} --> LAMP
+    {feeds} --> BUCK["Buck 12→5 V"] --> MCU
+```
 
 Recommended symbols/footprints:
 - Audio TRS jacks with switched normals (if you add mute/bypass).
 - MCP6002 in SOIC‑8 with DIP‑8 footprint option (adapter) for easy replacement.
 - Test pads: SUM, ADC, 5V, GND, D9.
+- SparkFun-style 6-pin FTDI header (DTR, TXO, RXI, VCC, CTS, GND) near the MCU edge.
+
+Production sanity checks:
+- Keep the ADC node <5 mm trace length and guard it with ground pour.
+- Drop TVS diodes near the 12 V entry and the lamp connector if you expect abuse.
+- If you spin a 4-layer PCB, dedicate an inner plane to analog ground and stitch it at the buffer and MCU references.
+- Bring the FTDI header outboard so you can flash the Pro Mini on an assembled unit without opening the enclosure fully.


### PR DESCRIPTION
## Summary
- update docs, BOM, and diagrams to call out the SparkFun Pro Mini and FTDI Basic programming workflow
- switch PlatformIO configuration and firmware annotations to the Pro Mini target and remove USB-specific defines
- expand build guidance with FTDI wiring notes and hardware placement advice for the programming header

## Testing
- `pio run` *(fails: PlatformIO CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db109dff488325b6a0ee6de2a30e6d