### PR TITLE
Fix FFT frame size for Pro Mini SRAM

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -24,7 +24,8 @@ flowchart TD
 ```
 
 - **Sampler** holds timing steady without ISRs so the analog porch can be debugged in isolation.
-- **FFT core** uses `arduinoFFT` with a Hann window you can audit in ROM.
+- **FFT core** uses `arduinoFFT` with a Hann window you can audit in ROM. 128-point frames stay inside the Pro Mini's
+  2 KB SRAM while still giving ~75 Hz bin spacing at 9.6 kHz sampling.
 - **Band picker** translates the panel knobs into bin ranges with guard rails.
 - **AGC + EMA** does the vibe-polishing—no hard clipping, no drama.
 - **Gamma mapper** makes LED brightness feel linear to human eyes.

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -19,7 +19,7 @@ static const uint8_t PIN_PWM   = 9;    // Timer1 OC1A output → MOSFET gate dri
 // -----------------------------------------------------------------------------
 // FFT / DSP constants — tuned for a 9.6 kHz sample rate which plays nicely with the loop timing.
 // -----------------------------------------------------------------------------
-static const uint16_t FFT_BIN_COUNT = 256;            // Power-of-two for the library FFT.
+static const uint16_t FFT_BIN_COUNT = 128;            // 128 keeps the double buffers under 2 KB SRAM on the Pro Mini.
 static const float    SAMPLE_RATE_HZ = 9600.0f;       // Set by our crude spin-wait sampler.
 static const uint32_t SAMPLE_PERIOD_US =              // Microseconds between samples.
     static_cast<uint32_t>(1000000.0f / SAMPLE_RATE_HZ + 0.5f);


### PR DESCRIPTION
## Summary
- reduce the FFT frame to 128 samples so the Pro Mini has enough SRAM for all working buffers
- document the 128-point FFT choice and resulting bin spacing in the firmware README

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db1410427c83258603fab7768a2b87